### PR TITLE
Fix missing libs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include libs/GenericDeviceInterfaceDLL.dll
+include libs/MindMedia_SDK.dll
+include libs/GenericDeviceInterfaceDLL_x64.dll
+include libs/msvcr100.dll
+include libs/msvcp100.dll
+include libs/mfc100.dll

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
-include libs/GenericDeviceInterfaceDLL.dll
-include libs/MindMedia_SDK.dll
-include libs/GenericDeviceInterfaceDLL_x64.dll
-include libs/msvcr100.dll
-include libs/msvcp100.dll
-include libs/mfc100.dll
+include timeflux_nexus/libs/GenericDeviceInterfaceDLL.dll
+include timeflux_nexus/libs/MindMedia_SDK.dll
+include timeflux_nexus/libs/GenericDeviceInterfaceDLL_x64.dll
+include timeflux_nexus/libs/msvcr100.dll
+include timeflux_nexus/libs/msvcp100.dll
+include timeflux_nexus/libs/mfc100.dll

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('timeflux_nexus/__init__.py') as f:
     VERSION = re.search('^__version__\s*=\s*\'(.*)\'', f.read(), re.M).group(1)
 
 dependencies = [
-    'timeflux @ git+https://https://github.com/timeflux/timeflux#egg=timeflux'
+    'timeflux @ git+https://github.com/timeflux/timeflux#egg=timeflux'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup(
     author='Pierre Clisson',
     author_email='contact@timeflux.io',
     url='https://timeflux.io',
+    include_package_data=True,
     install_requires=dependencies,
 )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ with open('README.md', 'rb') as f:
 with open('timeflux_nexus/__init__.py') as f:
     VERSION = re.search('^__version__\s*=\s*\'(.*)\'', f.read(), re.M).group(1)
 
+dependencies = [
+    'timeflux @ git+https://https://github.com/timeflux/timeflux#egg=timeflux'
+]
+
 setup(
     name='timeflux-nexus',
     packages=find_packages(exclude=['test']),
@@ -18,4 +22,5 @@ setup(
     author='Pierre Clisson',
     author_email='contact@timeflux.io',
     url='https://timeflux.io',
+    install_requires=dependencies,
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('timeflux_nexus/__init__.py') as f:
 
 setup(
     name='timeflux-nexus',
-    packages=find_packages(),
+    packages=find_packages(exclude=['test']),
     version=VERSION,
     description='Mind Media Nexus plugin.',
     long_description=DESCRIPTION,

--- a/timeflux_nexus/nodes/driver.py
+++ b/timeflux_nexus/nodes/driver.py
@@ -75,7 +75,7 @@ class Nexus(Node):
             libname = 'GenericDeviceInterfaceDLL.dll' if bitness == 32 else 'GenericDeviceInterfaceDLL_x64.dll'
         else:
             raise WorkerInterrupt('Operating system not compatible')
-        libpath = os.path.join(os.path.dirname(__file__), '../libs', libname)
+        libpath = os.path.join(os.path.dirname(__file__), '..', 'libs', libname)
         self.lib = CDLL(libpath)
 
     def _init_lib(self):


### PR DESCRIPTION
This changeset adds a manifest file to include the dll needed for this package to function properly. Note that this needs a `include_package_data=True` on the `setup.py` script, and since I was modifying that script, I added the timeflux dependency (which is, by the way, something that is consistently missing on the other timeflux_... packages).